### PR TITLE
feat: normalize generated ids

### DIFF
--- a/test/components/fancy-form/fixtures/data.html
+++ b/test/components/fancy-form/fixtures/data.html
@@ -1,0 +1,20 @@
+<label
+  for="GENERATED-0"
+>
+  First Name
+</label>
+<input
+  id="GENERATED-0"
+  name="firstName"
+  value="Michael"
+/>
+<label
+  for="GENERATED-1"
+>
+  Last Name
+</label>
+<input
+  id="GENERATED-1"
+  name="lastName"
+  value="Rawlings"
+/>

--- a/test/components/fancy-form/fixtures/data.json
+++ b/test/components/fancy-form/fixtures/data.json
@@ -1,0 +1,4 @@
+{
+  "firstName": "Michael",
+  "lastName": "Rawlings"
+}

--- a/test/components/fancy-form/index.marko
+++ b/test/components/fancy-form/index.marko
@@ -1,0 +1,5 @@
+<label for:scoped="first-name">First Name</label>
+<input id:scoped="first-name" name="firstName" value=input.firstName>
+
+<label for:scoped="last-name">Last Name</label>
+<input id:scoped="last-name" name="lastName" value=input.lastName>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -88,6 +88,25 @@ describe("findProjectFixtures", () => {
           "path": "(cwd)/test/components/container/index.marko",
         },
         Object {
+          "component": [Component "(cwd)/test/components/fancy-form/index.marko"],
+          "fixtures": Object {
+            "data": Object {
+              "ext": ".json",
+              "fixture": Object {
+                "firstName": "Michael",
+                "lastName": "Rawlings",
+              },
+              "name": "data",
+              "path": "(cwd)/test/components/fancy-form/fixtures/data.json",
+              "render": [Function],
+              "toString": [Function],
+            },
+          },
+          "fixturesPath": "(cwd)/test/components/fancy-form/fixtures",
+          "name": "fancy-form",
+          "path": "(cwd)/test/components/fancy-form/index.marko",
+        },
+        Object {
           "component": [Component "(cwd)/test/components/hello/index.marko"],
           "fixtures": Object {
             "data": Object {


### PR DESCRIPTION
BREAKING CHANGE: IDs are no longer always preserved

## Description

This PR updates the `default normalizer` in this project to replace all ids matching `/\d/` (used by Marko's generated ids and some other modules) with `GENERATED-` followed by the index of the ID as discovered when normalizing. This ensures a consistent ID across snapshots.

It also then walks through the DOM and finds any attributes which are using the generated ids and updates those as well.

## Motivation and Context

Currently without resetting Marko's internal ID counter you can have inconsistent snapshots. `@marko/testing-library` exposes a util to do this but it may not always be there. Other modules such as [makeup-next-id](https://github.com/makeup-js/makeup-next-id) also can create inconsistent ids across snapshots, however they also follow the same format and so are now normalized.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

